### PR TITLE
Fix autocompletion with new cli and add service keys management

### DIFF
--- a/cf/_cf
+++ b/cf/_cf
@@ -1,8 +1,14 @@
 #compdef cf
+help_arg=""
+cf_version=$(cf --version | awk '{print $3}' | sed -e 's/\.[0-9]\+.*//' | sed 's/\.//g')
+if [[ "$cf_version" -ge "622" ]] ; then
+	help_arg="-a"
+fi
+
 if [[ "${CF_ZSH_INCLUDE_SHORT}" == "true" ]] ; then 
-   cf_help=$(CF_COLOR=FALSE cf help | egrep -v '^\w' |  egrep -v 'CF_|HTTP' | tr ',' '\n' | awk '{print $1}' | egrep -v '\--|^\[|^cf$' | egrep '^[a-z]')
+   cf_help=$(CF_COLOR=FALSE cf help $help_arg | egrep -v '^\w' |  egrep -v 'CF_|HTTP' | tr ',' '\n' | awk '{print $1}' | egrep -v '\--|^\[|^cf$' | egrep '^[a-z]')
 else 
-   cf_help=$(CF_COLOR=FALSE cf help | egrep -v '^\w' | awk '{print $1}' | tr -d ',' | egrep -v '\--|^\[|^cf$|CF_|HTTP' | egrep '^[a-z]')
+   cf_help=$(CF_COLOR=FALSE cf help $help_arg | egrep -v '^\w' | awk '{print $1}' | tr -d ',' | egrep -v '\--|^\[|^cf$|CF_|HTTP' | egrep '^[a-z]')
 fi
 
 ######################### Util functions ##########################

--- a/cf/_cf
+++ b/cf/_cf
@@ -69,10 +69,12 @@ compadd_domains() {
 compadd_buildpacks() { 
 	compadd_tabley_thing_with_important_bit_in_first_position "buildpacks" "position" 
 } 
-
+compadd_service_keys() {
+	compadd - $(CF_COLOR=FALSE cf service-keys ${words[3]} | awk "/name/{a=1;next;}a" | awk '{print $1}')
+} 
 compadd_help_flags() { 
 	cmd=$words[2]
-	compadd - $(CF_COLOR=FALSE cf $cmd --help  | awk "/OPTIONS/{a=1;next;}a" | awk '{print $1}')
+	compadd - $(CF_COLOR=FALSE cf $cmd --help | awk "/OPTIONS/{a=1;next;}a" | awk '{print $1}')
 }
 
 compadd_message() { 
@@ -104,14 +106,47 @@ create_route() {
 #$1 is the command (target, app, services, create-service etc)
 find_command_flags() { 
 	case $words[2] in 
-		"target")
+		"target" | "t")
 			case $words[-2] in 
 				-o) compadd_orgs;;
 				-s) compadd_spaces;;
 				*) compadd_help_flags;;
 			esac
 			;;
-		"bind-service") #A positional command, APP then SERVICE-INSTANCE
+		"service-keys") #A positional command, APP then SERVICE-INSTANCE
+			case ${#words} in 
+				3) compadd_service_instances;;
+				4) command_complete;;
+			esac
+			;; #service-keys
+		"create-service-key") #A positional command, APP then SERVICE-INSTANCE
+			case ${#words} in 
+				3) compadd_service_instances;;
+				*) compadd_help_flags;;
+			esac
+			;; #create-service-key
+		"service-key") #A positional command, APP then SERVICE-INSTANCE
+			case ${#words} in 
+				3) compadd_service_instances;;
+				4) compadd_service_keys;;
+				5) command_complete;;
+			esac
+			;; #service-key
+		"delete-service-key") #A positional command, APP then SERVICE-INSTANCE
+			case ${#words} in 
+				3) compadd_service_instances;;
+				4) compadd_service_keys;;
+				5) command_complete;;
+			esac
+			;; #delete-service-key
+		"unbind-service" | "us") #A positional command, APP then SERVICE-INSTANCE
+			case ${#words} in 
+				3) compadd_apps;; 
+				4) compadd_service_instances;;
+				5) command_complete;;
+			esac
+			;; #unbind-service
+		"bind-service" | "bs") #A positional command, APP then SERVICE-INSTANCE
 			case ${#words} in 
 				3) compadd_apps;; 
 				4) compadd_service_instances;;


### PR DESCRIPTION
First thank you for this oh-my-zsh plugin it saves me a lot of time :)

I fix the commands auto-completion when we use the latest cli version, indeed version 6.22 change the help command and was showing commands in columns and don't show all commands. We now have to use the args "-a" to have the same command as before.
This argument is used only if user have a cli version greater or equals to cli version 6.22 in this PR.

I've also add service key management in the auto-completion, native cli commands are painful and with this little trick in this oh-my-zsh plugin help a lot.

Hope someone will find this PR interesting